### PR TITLE
Add container support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ nextflow run nextstrain/zika-tutorial-nextflow -r main --help
 
 ```
 N E X T F L O W  ~  version 21.10.6
-Launching `main.nf` [tiny_jepsen] - revision: 3efe125160
+Launching `main.nf` [naughty_pasteur] - revision: f50f9d379a
 
   Usage:
    The typical command for running the pipeline are as follows:
@@ -38,11 +38,11 @@ Launching `main.nf` [tiny_jepsen] - revision: 3efe125160
    --auspice_config                   Auspice config file [default: 'false']
    Optional augur arguments
    --filter_args                      Parameters passed to filter [default: '--group-by country year month --sequences-per-group 20 --min-date 2012']
-   --align_args                       Parameters passed to filter [default: '--group-by country year month --sequences-per-group 20 --min-date 2012']
-   --tree_args                        Parameters passed to filter [default: '--group-by country year month --sequences-per-group 20 --min-date 2012']
-   --refine_args                      Parameters passed to filter [default: '--group-by country year month --sequences-per-group 20 --min-date 2012']
-   --ancestral_args                   Parameters passed to filter [default: '--group-by country year month --sequences-per-group 20 --min-date 2012']
-   --traits_args                      Parameters passed to filter [default: '--group-by country year month --sequences-per-group 20 --min-date 2012']
+   --align_args                       Parameters passed to align [default: '--fill-gaps']
+   --tree_args                        Parameters passed to tree [default: '']
+   --refine_args                      Parameters passed to refine [default: '--timetree --coalescent opt --date-confidence --date-inference marginal --clock-filter-iqd 4']
+   --ancestral_args                   Parameters passed to ancestral [default: '--inference joint']
+   --traits_args                      Parameters passed to traits [default: '--columns region country --confidence']
    Optional arguments:
    --augur_app                        Augur executable [default: 'augur']
    --outdir                           Output directory to place final output [default: 'results']

--- a/README.md
+++ b/README.md
@@ -10,6 +10,48 @@ cd zika-tutorial-nextflow
 nextflow run main.nf
 ```
 
+## Help Statement
+
+Assuming you have a working installation of [Nextflow](https://www.nextflow.io/docs/latest/getstarted.html)
+
+```
+nextflow run nextstrain/zika-tutorial-nextflow -r main --help
+```
+
+<details><summary>See help statement</summary>
+
+```
+N E X T F L O W  ~  version 21.10.6
+Launching `main.nf` [tiny_jepsen] - revision: 3efe125160
+
+  Usage:
+   The typical command for running the pipeline are as follows:
+   nextflow run nextflow/zika-tutorial-nextflow -r main -profile docker
+   
+   Input Files:
+   --sequences                        Sequences fasta [default: 'false']
+   --metadata                         Metadata tsv file [default: 'false']
+   --exclude                          List of excluded sequences file [default: 'false']
+   --reference                        Reference genbank file [default: 'false']
+   --colors                           Colors tsv file [default: 'false']
+   --lat_longs                        Latitude and longituide file [default: 'false']
+   --auspice_config                   Auspice config file [default: 'false']
+   Optional augur arguments
+   --filter_args                      Parameters passed to filter [default: '--group-by country year month --sequences-per-group 20 --min-date 2012']
+   --align_args                       Parameters passed to filter [default: '--group-by country year month --sequences-per-group 20 --min-date 2012']
+   --tree_args                        Parameters passed to filter [default: '--group-by country year month --sequences-per-group 20 --min-date 2012']
+   --refine_args                      Parameters passed to filter [default: '--group-by country year month --sequences-per-group 20 --min-date 2012']
+   --ancestral_args                   Parameters passed to filter [default: '--group-by country year month --sequences-per-group 20 --min-date 2012']
+   --traits_args                      Parameters passed to filter [default: '--group-by country year month --sequences-per-group 20 --min-date 2012']
+   Optional arguments:
+   --augur_app                        Augur executable [default: 'augur']
+   --outdir                           Output directory to place final output [default: 'results']
+   --help                             This usage statement.
+   --check_software                   Check if software dependencies are available.
+```
+
+</details>
+
 ## Demonstration
 
 Augur commands were wrapped in processes (similar to Snakemake's rules) and placed in the `modules/augur.nf`. Nextflow processes were imported into `main.nf` and connected via Nextflow channels.

--- a/configs/containers.config
+++ b/configs/containers.config
@@ -1,0 +1,3 @@
+process {
+  container = "nextstrain/base:latest"
+}

--- a/main.nf
+++ b/main.nf
@@ -19,6 +19,41 @@ include { index;
 // 2) any fine-tuned flags for different viruses
 // 3) any specific default references for different viruses
 
+// Define functions
+def helpMessage() {
+  log.info """
+  Usage:
+   The typical command for running the pipeline are as follows:
+   nextflow run nextflow/zika-tutorial-nextflow -r main -profile docker
+   
+   Input Files:
+   --sequences                        Sequences fasta [default: '$params.sequences']
+   --metadata                         Metadata tsv file [default: '$params.metadata']
+   --exclude                          List of excluded sequences file [default: '$params.exclude']
+   --reference                        Reference genbank file [default: '$params.reference']
+   --colors                           Colors tsv file [default: '$params.lat_longs']
+   --lat_longs                        Latitude and longituide file [default: '$params.lat_longs']
+   --auspice_config                   Auspice config file [default: '$params.auspice_config']
+   Optional augur arguments
+   --filter_args                      Parameters passed to filter [default: '$params.filter_args']
+   --align_args                       Parameters passed to align [default: '$params.align_args']
+   --tree_args                        Parameters passed to tree [default: '$params.tree_args']
+   --refine_args                      Parameters passed to refine [default: '$params.refine_args']
+   --ancestral_args                   Parameters passed to ancestral [default: '$params.ancestral_args']
+   --traits_args                      Parameters passed to traits [default: '$params.traits_args']
+   Optional arguments:
+   --augur_app                        Augur executable [default: '$params.augur_app']
+   --outdir                           Output directory to place final output [default: '$params.outdir']
+   --help                             This usage statement.
+   --check_software                   Check if software dependencies are available.
+  """
+}
+
+if ( params.help) {
+  helpMessage()
+  exit 0
+}
+
 process get_versions {
   publishDir "${params.outdir}", mode: 'copy'
   output: path("versions.txt")
@@ -70,12 +105,19 @@ workflow {
   // Define Input channels
   fetch_zika_tutorial()
   sequences_ch = setDefaultIfNotDefined(params.sequences, fetch_zika_tutorial.out, 0)
+    | view { "sequences: $it"}
   metadata_ch = setDefaultIfNotDefined(params.metadata, fetch_zika_tutorial.out, 1)
+    | view { "metadata: $it"}
   exclude_ch = setDefaultIfNotDefined(params.exclude, fetch_zika_tutorial.out, 5)
+    | view { "exclude: $it"}
   reference_ch = setDefaultIfNotDefined(params.reference, fetch_zika_tutorial.out, 6)
+    | view { "reference: $it"}
   colors_ch = setDefaultIfNotDefined(params.colors, fetch_zika_tutorial.out, 3)
+    | view { "colors: $it"}
   lat_longs_ch = setDefaultIfNotDefined(params.lat_longs, fetch_zika_tutorial.out, 4)
+    | view { "lat longs: $it"}
   auspice_config_ch = setDefaultIfNotDefined(params.auspice_config, fetch_zika_tutorial.out, 2)
+    | view { "auspice config: $it"}
 
   // Run pipeline (chain together processes and add other params on the way)
   channel.of("zika")

--- a/main.nf
+++ b/main.nf
@@ -1,11 +1,18 @@
-#!/usr/bin/env nextflow
+#! /usr/bin/env nextflow
 
 nextflow.enable.dsl=2
 
 // ===== MODULES ==============//
 // Import reusable and bespoke modules
-include { index; filter; align; tree; refine;
-          ancestral; translate; traits; export } from './modules/augur.nf'
+include { index;
+          filter;
+          align;
+          tree;
+          refine;
+          ancestral;
+          translate;
+          traits;
+          export } from './modules/augur.nf'
 
 // This section could include but is not limited to:
 // 1) any bespoke modules for preprocessing data

--- a/nextflow.config
+++ b/nextflow.config
@@ -23,7 +23,7 @@ params {
   outdir = "results"
 
   // link any executables
-  docker_img = 'nextstrain/base'
+  docker_img = 'nextstrain/base' // currently ignored
   augur_app = "augur"
 
   threads = 4
@@ -49,31 +49,37 @@ profiles {
   }
 //  pbs   { includeConfig 'configs/pbs.config' }
 //  aws   { includeConfig 'configs/aws.config'}
-//  docker {
-//    docker.enabled = true
-//    docker.runOptions = '-u \$(id -u):\$(id -g)'
-//  }
-//  docker_m1 {
-//    docker.enabled = true
-//    docker.runOptions = '-u \$(id -u):\$(id -g) --platform linux/amd64'
-//  }
-//  singularity {
-//    singularity.enabled = true
-//    singularity.autoMounts = true
-//  }
+  docker {
+    includeConfig 'configs/custom.config'
+    includeConfig 'configs/containers.config'
+    docker.enabled = true
+    docker.userEmulation = true
+    //docker.runOptions = '-u \$(id -u):\$(id -g)'
+  }
+  docker_m1 {
+    includeConfig 'configs/custom.config'
+    includeConfig 'configs/containers.config'
+    docker.enabled = true
+    docker.userEmulation   = true
+    //docker.runOptions = '-u \$(id -u):\$(id -g) --platform linux/amd64'
+  }
+  singularity {
+    includeConfig 'configs/custom.config'
+    includeConfig 'configs/containers.config'
+    singularity.enabled = true
+    singularity.autoMounts = true
+  }
 //  custom { includeConfig 'configs/custom.config' }
 
 // test {} // pull a test dataset, and run nextflow
 }
 
-process.container = "$params.docker_img"
-
 timeline {
-  enabled = true
+  enabled = false
   file = "$params.outdir/timeline.html"
 }
 
 report {
-  enabled = true
+  enabled = false
   file = "$params.outdir/report.html"
 }


### PR DESCRIPTION
### Description of proposed changes

* Add docker and singularity support following [nextflow instructions](https://www.nextflow.io/docs/latest/singularity.html#singularity-docker-hub). 
* See commit messages

### Testing

Assuming reviewer has [nextflow installed](https://www.nextflow.io/docs/latest/getstarted.html): 

1. Test help statement

```
nextflow run nextstrain/zika-tutorial-nextflow -r add_containers --help
```

<details><summary>Expected output</summary>

```
N E X T F L O W  ~  version 21.10.6
Launching `nextstrain/zika-tutorial-nextflow` [gigantic_hodgkin] - revision: bddf64f63c [add_containers]

  Usage:
   The typical command for running the pipeline are as follows:
   nextflow run nextflow/zika-tutorial-nextflow -r main -profile docker
   
   Input Files:
   --sequences                        Sequences fasta [default: 'false']
   --metadata                         Metadata tsv file [default: 'false']
   --exclude                          List of excluded sequences file [default: 'false']
   --reference                        Reference genbank file [default: 'false']
   --colors                           Colors tsv file [default: 'false']
   --lat_longs                        Latitude and longituide file [default: 'false']
   --auspice_config                   Auspice config file [default: 'false']
   Optional augur arguments
   --filter_args                      Parameters passed to filter [default: '--group-by country year month --sequences-per-group 20 --min-date 2012']
   --align_args                       Parameters passed to align [default: '--fill-gaps']
   --tree_args                        Parameters passed to tree [default: '']
   --refine_args                      Parameters passed to refine [default: '--timetree --coalescent opt --date-confidence --date-inference marginal --clock-filter-iqd 4']
   --ancestral_args                   Parameters passed to ancestral [default: '--inference joint']
   --traits_args                      Parameters passed to traits [default: '--columns region country --confidence']
   Optional arguments:
   --augur_app                        Augur executable [default: 'augur']
   --outdir                           Output directory to place final output [default: 'results']
   --help                             This usage statement.
   --check_software                   Check if software dependencies are available.
```

</details>

2. Test docker, singularity or HPC singularity, depending on reviewer's computing environment:

```
nextflow run nextstrain/zika-tutorial-nextflow -r add_containers -profile docker
```

or 

```
nextflow run nextstrain/zika-tutorial-nextflow -r add_containers -profile singularity
```

or on an HPC

```
nextflow run nextstrain/zika-tutorial-nextflow -r add_containers -profile slurm,singularity
```

<details><summary>Expected output</summary>

```
N E X T F L O W  ~  version 21.10.6
Launching `nextstrain/zika-tutorial-nextflow` [determined_agnesi] - revision: bddf64f63c [add_containers]
executor >  local (10)
[7f/c32343] process > fetch_zika_tutorial [100%] 1 of 1 ✔
[b5/79965a] process > index (1)           [100%] 1 of 1 ✔
[e1/7853f2] process > filter (1)          [100%] 1 of 1 ✔
[b2/16d1e8] process > align (1)           [100%] 1 of 1 ✔
[6d/cb7523] process > tree (1)            [100%] 1 of 1 ✔
[35/f47d04] process > refine (1)          [100%] 1 of 1 ✔
[26/876d8d] process > ancestral (1)       [100%] 1 of 1 ✔
[7d/5fe7ae] process > translate (1)       [100%] 1 of 1 ✔
[25/f26bde] process > traits (1)          [100%] 1 of 1 ✔
[ba/20af4a] process > export (1)          [100%] 1 of 1 ✔
auspice config: /Users/jenchang/github/nextstrain/work/7f/c32343d36901a12d8772276ba70b19/auspice_config.json
metadata: /Users/jenchang/github/nextstrain/work/7f/c32343d36901a12d8772276ba70b19/metadata.tsv
sequences: /Users/jenchang/github/nextstrain/work/7f/c32343d36901a12d8772276ba70b19/sequences.fasta
exclude: /Users/jenchang/github/nextstrain/work/7f/c32343d36901a12d8772276ba70b19/lat_longs.tsv
lat longs: /Users/jenchang/github/nextstrain/work/7f/c32343d36901a12d8772276ba70b19/dropped_strains.txt
colors: /Users/jenchang/github/nextstrain/work/7f/c32343d36901a12d8772276ba70b19/colors.tsv
reference: /Users/jenchang/github/nextstrain/work/7f/c32343d36901a12d8772276ba70b19/zika_outgroup.gb
Completed at: 18-Jan-2023 11:16:20
Duration    : 1m 30s
CPU hours   : (a few seconds)
Succeeded   : 10
```

</details>